### PR TITLE
CB: remove colcon as buildtool_depend in package.xml

### DIFF
--- a/ros_mscl/package.xml
+++ b/ros_mscl/package.xml
@@ -9,7 +9,6 @@
   <license>MIT</license>
   <url type="website">https://github.com/LORD-MicroStrain/ROS-MSCL</url>
 
-  <buildtool_depend>colcon</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>rclcpp</depend>


### PR DESCRIPTION
This was preventing the dependency from installing